### PR TITLE
Add a search endpoint to REST API wrapper around neo4j database

### DIFF
--- a/kg/api.py
+++ b/kg/api.py
@@ -7,16 +7,18 @@ app = Flask(__name__)
 client = Neo4jClient()
 
 
-@app.route("/search", methods=["POST"])
+@app.route("/search", methods=["GET"])
 def search():
     disease = request.json.get("disease")
     geolocation = request.json.get("geolocation")
     pathogen = request.json.get("pathogen")
     timestamp = request.json.get("timestamp")
     symptom = request.json.get("symptom")
+    limit = request.json.get("limit")
 
-    search_results = client.query_graph(disease, geolocation, pathogen,
-                                        timestamp, symptom)
+    search_results = client.query_graph(
+        disease, geolocation, pathogen, timestamp, symptom, limit
+    )
     return_value = {}
     for path_index, path in enumerate(search_results):
         return_value[path_index] = []

--- a/kg/api.py
+++ b/kg/api.py
@@ -1,0 +1,29 @@
+from flask import Flask, request, jsonify
+from client import client
+
+import neo4j
+
+app = Flask(__name__)
+
+
+@app.route("/search", methods=["POST"])
+def search():
+    disease = request.json.get("disease")
+    geolocation = request.json.get("geolocation")
+    pathogen = request.json.get("pathogen")
+    timestamp = request.json.get("timestamp")
+    symptom = request.json.get("symptom")
+
+    search_results = client.query_graph(disease, geolocation, pathogen,
+                                      timestamp, symptom)
+    return_value = {}
+    for path_index, path in enumerate(search_results):
+        return_value[path_index] = []
+        for path_compartment in path:
+            if isinstance(path_compartment, neo4j.graph.Node):
+                dict_path_compartment = dict(path_compartment)
+                return_value[path_index].append(dict_path_compartment)
+            elif path_compartment is not None:
+                return_value[path_index].append(path_compartment.type)
+
+    return jsonify(return_value)

--- a/kg/api.py
+++ b/kg/api.py
@@ -1,9 +1,10 @@
 from flask import Flask, request, jsonify
-from client import client
+from client import Neo4jClient
 
 import neo4j
 
 app = Flask(__name__)
+client = Neo4jClient()
 
 
 @app.route("/search", methods=["POST"])
@@ -15,7 +16,7 @@ def search():
     symptom = request.json.get("symptom")
 
     search_results = client.query_graph(disease, geolocation, pathogen,
-                                      timestamp, symptom)
+                                        timestamp, symptom)
     return_value = {}
     for path_index, path in enumerate(search_results):
         return_value[path_index] = []

--- a/kg/client.py
+++ b/kg/client.py
@@ -1,0 +1,94 @@
+from typing import Any, List, Optional
+from typing_extensions import TypeAlias
+
+import neo4j
+from neo4j import GraphDatabase, Transaction, unit_of_work
+
+__all__ = ["client"]
+
+TxResult: TypeAlias = Optional[List[List[Any]]]
+
+
+class Neo4jClient:
+    """A client to Neo4j."""
+
+    _session: Optional[neo4j.Session]
+
+    def __init__(
+        self,
+    ) -> None:
+        """Initialize the Neo4j client."""
+        # We initialize this so that the del doesn't error if some
+        # exception occurs before it's initialized
+        self.driver = None
+        url = "bolt://localhost:7687"
+        user = None
+        password = None
+
+        # Set max_connection_lifetime to something smaller than the timeouts
+        # on the server or on the way to the server. See
+        # https://github.com/neo4j/neo4j-python-driver/issues/316#issuecomment-564020680
+        self.driver = GraphDatabase.driver(
+            url,
+            auth=(user, password) if user and password else None,
+            max_connection_lifetime=3 * 60,
+        )
+        self._session = None
+
+    def __del__(self):
+        if self.driver is not None:
+            self.driver.close()
+
+    def query_tx(self, query: str, **query_params) -> Optional[TxResult]:
+        with self.driver.session() as session:
+            values = session.read_transaction(do_cypher_tx, query, **query_params)
+        return values
+
+    def query_graph(
+        self,
+        disease: str = None,
+        geolocation: str = None,
+        pathogen: str = None,
+        timestamp: str = None,
+        symptom: str = None,
+    ):
+        included_labels = []
+        included_names = []
+        where_clauses = []
+        search_query = "MATCH (n)-[r_m:mentions]->(m)"
+        query_parameters = {}
+        if timestamp is not None:
+            query_parameters["timestamp"] = timestamp
+            where_clauses.append("n.timestamp = $timestamp")
+        if disease is not None:
+            included_labels.append("disease")
+            included_names.append(disease)
+        if geolocation is not None:
+            included_labels.append("geoloc")
+            included_names.append(geolocation)
+        if pathogen is not None:
+            included_labels.append("pathogen")
+            included_names.append(pathogen)
+        if included_labels and included_names:
+            query_parameters["labels"] = included_labels
+            query_parameters["names"] = included_names
+            where_clauses.append(
+                "m.name IN $names AND ANY(label IN labels(m) WHERE label IN $labels)")
+        if where_clauses:
+            search_query += " WHERE " + " AND ".join(where_clauses)
+        if symptom is not None:
+            query_parameters["symptom"] = symptom
+            search_query += " OPTIONAL MATCH (m)-[r_ph:has_phenotype]->(ph)"
+            search_query += " WHERE ph.name = $symptom"
+        search_query += " RETURN n, r_m, m, r_ph, ph"
+
+        return self.query_tx(search_query, **query_parameters)
+
+
+@unit_of_work()
+def do_cypher_tx(tx: Transaction, query: str, **query_params) -> List[List]:
+    result = tx.run(query, parameters=query_params)
+    return [record.values() for record in result]
+
+
+client = Neo4jClient()

--- a/kg/client.py
+++ b/kg/client.py
@@ -61,19 +61,19 @@ class Neo4jClient:
             query_parameters["timestamp"] = timestamp
         if disease is not None:
             search_query += (
-                " MATCH (n)-[r_d:mentions]->(disease:disease {name: $disease})-[:isa*0..]->(disease_isa:disease)"
+                " MATCH (n)-[r_d:mentions]->(disease:disease {name:$disease})<-[:isa*0..]-(disease_isa:disease)"
             )
             query_parameters["disease"] = disease
             return_value += ", r_d, disease, disease_isa"
         if geolocation is not None:
             search_query += (
-                " MATCH (n)-[r_g:mentions]->(geolocation:geoloc {name: $geolocation})-[:isa*0..]->(geolocation_isa:geoloc)"
+                " MATCH (n)-[r_g:mentions]->(geolocation:geoloc {name:$geolocation})<-[:isa*0..]-(geolocation_isa:geoloc)"
             )
             query_parameters["geolocation"] = geolocation
             return_value += ", r_g, geolocation, geolocation_isa"
         if pathogen is not None:
             search_query += (
-                " MATCH (n)-[r_p:mentions]->(pathogen:pathogen {name: $pathogen})-[:isa*0..]->(pathogen_isa:pathogen)"
+                " MATCH (n)-[r_p:mentions]->(pathogen:pathogen {name:$pathogen})<-[:isa*0..]-(pathogen_isa:pathogen)"
             )
             query_parameters["pathogen"] = pathogen
             return_value += ", r_p, pathogen, pathogen_isa"
@@ -82,11 +82,11 @@ class Neo4jClient:
             first_search_query, second_search_query = search_query, search_query
             first_search_query += (" OPTIONAL MATCH (disease:disease)-["
                              "r_s:has_phenotype]->(symptom:disease {name: "
-                             "$symptom})-[:isa*0..]->(symptom_isa:disease)"
+                             "$symptom})<-[:isa*0..]-(symptom_isa:disease)"
                              )
             first_search_query += return_value
             second_search_query += (" OPTIONAL MATCH (n)-[r_s:mentions]->("
-                             "symptom:disease {name:$symptom})-[:isa*0..]->("
+                             "symptom:disease {name:$symptom})<-[:isa*0..]-("
                              "symptom_isa:disease) "
                              )
             second_search_query += return_value

--- a/kg/client.py
+++ b/kg/client.py
@@ -53,7 +53,7 @@ class Neo4jClient:
         symptom: str = None,
         limit: int = None
     ):
-        search_query = "MATCH (n)-[:mentions]->(m)"
+        search_query = "MATCH (n:alert)-[:mentions]->(m)"
         query_parameters = {}
         return_value = " RETURN n"
         if timestamp is not None:

--- a/kg/client.py
+++ b/kg/client.py
@@ -82,7 +82,6 @@ class Neo4jClient:
         search_query += return_value
         if limit :
             search_query += f" LIMIT {limit}"
-        breakpoint()
         return self.query_tx(search_query, **query_parameters)
 
 

--- a/kg/client.py
+++ b/kg/client.py
@@ -4,7 +4,7 @@ from typing_extensions import TypeAlias
 import neo4j
 from neo4j import GraphDatabase, Transaction, unit_of_work
 
-__all__ = ["client"]
+__all__ = ["Neo4jClient"]
 
 TxResult: TypeAlias = Optional[List[List[Any]]]
 
@@ -51,36 +51,56 @@ class Neo4jClient:
         pathogen: str = None,
         timestamp: str = None,
         symptom: str = None,
+        limit: int = None
     ):
-        where_clauses = []
         search_query = "MATCH (n)-[:mentions]->(m)"
         query_parameters = {}
-        return_value = ' RETURN n, '
-        # TODO: add isa* relationships for all filters
-        # TODO: symptoms: it's either mentioned just like a disease or a symptom of a disease which is mentioned
-        # TODO: allow for a limit option
-        if disease is not None:
-            search_query += " MATCH (n)-[r_d:mentions]->(disease:disease {name: $disease})"
-            query_parameters["disease"] = disease
-            return_value += 'r_d, disease, '
-        if geolocation is not None:
-            search_query += " MATCH (n)-[r_g:mentions]->(geolocation:geolocation {name: $geolocation})"
-            query_parameters["geolocation"] = geolocation
-            return_value += 'r_g, geolocation, '
-        if pathogen is not None:
-            search_query += " MATCH (n)-[r_p:mentions]->(pathogen:pathogen {name: $pathogen})"
-            query_parameters["pathogen"] = pathogen
-            return_value += 'r_p, pathogen, '
+        return_value = " RETURN n"
         if timestamp is not None:
-            where_clauses.append("n.timestamp = $timestamp")
+            search_query += " WHERE n.timestamp = $timestamp"
             query_parameters["timestamp"] = timestamp
-        if where_clauses:
-            search_query += " WHERE " + " AND ".join(where_clauses)
+        if disease is not None:
+            search_query += (
+                " MATCH (n)-[r_d:mentions]->(disease:disease {name: $disease})-[:isa*0..]->(disease_isa:disease)"
+            )
+            query_parameters["disease"] = disease
+            return_value += ", r_d, disease, disease_isa"
+        if geolocation is not None:
+            search_query += (
+                " MATCH (n)-[r_g:mentions]->(geolocation:geoloc {name: $geolocation})-[:isa*0..]->(geolocation_isa:geoloc)"
+            )
+            query_parameters["geolocation"] = geolocation
+            return_value += ", r_g, geolocation, geolocation_isa"
+        if pathogen is not None:
+            search_query += (
+                " MATCH (n)-[r_p:mentions]->(pathogen:pathogen {name: $pathogen})-[:isa*0..]->(pathogen_isa:pathogen)"
+            )
+            query_parameters["pathogen"] = pathogen
+            return_value += ", r_p, pathogen, pathogen_isa"
         if symptom is not None:
-            search_query += " OPTIONAL MATCH (disease:disease)-[r_ph:has_phenotype]->({symptom:disease {name: $symptom}})"
+            return_value += ", r_s, symptom, symptom_isa"
+            first_search_query, second_search_query = search_query, search_query
+            first_search_query += (" OPTIONAL MATCH (disease:disease)-["
+                             "r_s:has_phenotype]->(symptom:disease {name: "
+                             "$symptom})-[:isa*0..]->(symptom_isa:disease)"
+                             )
+            first_search_query += return_value
+            second_search_query += (" OPTIONAL MATCH (n)-[r_s:mentions]->("
+                             "symptom:disease {name:$symptom})-[:isa*0..]->("
+                             "symptom_isa:disease) "
+                             )
+            second_search_query += return_value
+            if limit:
+                first_search_query += f" LIMIT {limit}"
+                second_search_query += f" LIMIT {limit}"
+                search_query = first_search_query + " UNION " + second_search_query
+            else:
+                search_query = first_search_query + " UNION " + second_search_query
             query_parameters["symptom"] = symptom
-        search_query += return_value
-
+        else:
+            search_query += return_value
+            if limit:
+                search_query += f" LIMIT {limit}"
         return self.query_tx(search_query, **query_parameters)
 
 


### PR DESCRIPTION
This PR creates a REST API wrapper around the neo4j database with a new endpoint called `search` where users can pass in (all optional) parameters: disease, geolocation, symptom, pathogen, alert time, and return limit.  

A resulting cypher query is then constructed from the passed in parameters and is used to query the connected neo4j database. The subgraph surrounding the corresponding alerts will be returned.

Currently, the return value from the endpoint is a place-holder. 
