### PR TITLE
Adapt Dockerfile for deployment

### DIFF
--- a/kg/Dockerfile
+++ b/kg/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update -y \
         gfortran \
         pkg-config \
         python3.11 \
+        python3.11-dev \
     && apt-get purge -y imagemagick imagemagick-6-common \
     && curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
 

--- a/kg/Dockerfile
+++ b/kg/Dockerfile
@@ -66,7 +66,6 @@ RUN python3.10 -m pip install fastapi \
     networkx \
     gunicorn
 
-RUN git clone https://github.com/gyorilab/outbreak_kg.git /sw/outbreak_kg
 
 # This is for coocurrence
 #COPY nodes.tsv /sw/nodes.tsv

--- a/kg/Dockerfile
+++ b/kg/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 # Needed to forego timezone configuration
 ENV DEBIAN_FRONTEND=noninteractive
@@ -32,11 +32,13 @@ RUN apt-get update -y \
         liblapack-dev \
         libblas-dev \
         gfortran \
-        pkg-config \
-        python3.11 \
-        python3.11-dev \
-    && apt-get purge -y imagemagick imagemagick-6-common \
-    && curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
+        pkg-config
+
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt update -y
+RUN apt -y install python3.10 python3.10-dev
+RUN apt-get purge -y imagemagick imagemagick-6-common
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
 
 RUN curl -fsSL https://debian.neo4j.com/neotechnology.gpg.key | apt-key add -
 RUN add-apt-repository "deb https://debian.neo4j.com stable 4.4"
@@ -50,9 +52,9 @@ RUN echo "dbms.security.procedures.unrestricted=apoc.*" >> /etc/neo4j/neo4j.conf
 
 # Fixes ERROR: Cannot uninstall 'blinker'. It is a distutils installed project
 # and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.
-RUN python3.11 -m pip install --ignore-installed blinker
+RUN python3.10 -m pip install --ignore-installed blinker
 
-RUN python3.11 -m pip install fastapi \
+RUN python3.10 -m pip install fastapi \
     uvicorn \
     "neo4j<5" \
     tqdm \
@@ -62,7 +64,6 @@ RUN python3.11 -m pip install fastapi \
     cython \
     pandas \
     networkx \
-    gilda \
     gunicorn
 
 RUN git clone https://github.com/gyorilab/outbreak_kg.git /sw/outbreak_kg
@@ -70,6 +71,10 @@ RUN git clone https://github.com/gyorilab/outbreak_kg.git /sw/outbreak_kg
 # This is for coocurrence
 #COPY nodes.tsv /sw/nodes.tsv
 #COPY edges.tsv /sw/edges.tsv
+COPY alerts.zip /sw/alerts.zip
+RUN cd /sw/ && \
+    unzip /sw/alerts.zip
+RUN mv /sw/eidos_input /sw/alerts
 
 COPY mesh_hierarchy_edges.tsv /sw/mesh_hierarchy_edges.tsv
 COPY mesh_hierarchy_nodes.tsv /sw/mesh_hierarchy_nodes.tsv
@@ -103,6 +108,10 @@ RUN neo4j-admin import --delimiter='TAB' --skip-duplicate-nodes=true --skip-bad-
 
 ENV DOCKERIZED="TRUE"
 ENV NEO4J_URL="bolt://localhost:7687"
+
+RUN python3.10 -c "import nltk;nltk.download('stopwords');nltk.download('punkt_tab')"
+RUN python3.10 -m pip install git+https://github.com/gyorilab/gilda.git
+RUN python3.10 -m gilda.resources
 
 COPY api.py api.py
 COPY client.py client.py

--- a/kg/client.py
+++ b/kg/client.py
@@ -86,6 +86,7 @@ class Neo4jClient:
         search_query = "MATCH (n:alert)-[:mentions]->(m)"
         query_parameters = {}
         return_value = " RETURN DISTINCT n, n.timestamp"
+        result_elements = []
         if timestamp is not None:
             search_query += " WHERE n.timestamp = $timestamp"
             query_parameters["timestamp"] = timestamp
@@ -93,7 +94,7 @@ class Neo4jClient:
             search_query += " MATCH (n:alert)-[r_d:mentions]->(disease:disease)-[:isa*0..]->(disease_isa:disease {name: $disease})"
             query_parameters["disease"] = disease
             return_value += ", disease, disease_isa"
-            result_elements = ['disease']
+            result_elements.append('disease')
         if geolocation is not None:
             search_query += (
                 " MATCH (n:alert)-[r_g:mentions]->(geolocation:geoloc)-[:isa*0..]->(geolocation_isa:geoloc {name: $geolocation})"

--- a/kg/startup.sh
+++ b/kg/startup.sh
@@ -16,4 +16,4 @@ done
 neo4j status
 
 echo "Running REST API"
-gunicorn --bind 0.0.0.0:8771 api:app
+gunicorn -t 600 --bind 0.0.0.0:8771 api:app


### PR DESCRIPTION
This PR changes the Dockerfile to install Python3.11 dev instead of Python3.11 so that we can install python packages that contain c files (i.e. `adeft` which is a dependency for `gilda`). Additonally, we remove an unnessary `git clone` statement of the `outbreak_kg` project to avoid adding duplicate files to the docker container. 

The container REST api has been tested with the `curl` command: 
`curl -X GET "http://0.0.0.0:8771/search" \
-H "Content-Type: application/json" \
-d '{
  "timestamp": "2000-10-22 19:50:00",
  "geolocation": "North Carolina",
  "pathogen": "West Nile virus",
  "disease": "Gerodermia osteodysplastica",
  "symptom": "Bone Diseases, Metabolic"
}'`

